### PR TITLE
feat: new IIR backend `ssm` for faster biquads on GPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build/
 dist/
 sphinx-doc/build
+*.pyc
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "matplotlib", 
     "networkx",
     "einops",
+    "torchlpc",
+    "torchcomp",
 #"monarch-cuda @ git+https://github.com/HazyResearch/flash-fft-conv.git#subdirectory=csrc/flashfftconv",
 #    "flashfftconv @ git+https://github.com/HazyResearch/flash-fft-conv.git",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "matplotlib", 
     "networkx",
     "einops",
-    "torchlpc",
+    "torchlpc>=0.4",
     "torchcomp",
 #"monarch-cuda @ git+https://github.com/HazyResearch/flash-fft-conv.git#subdirectory=csrc/flashfftconv",
 #    "flashfftconv @ git+https://github.com/HazyResearch/flash-fft-conv.git",

--- a/sphinx-doc/source/references/refs.bib
+++ b/sphinx-doc/source/references/refs.bib
@@ -1412,3 +1412,10 @@ pages={856--860},
 year={2024},
 organization={IEEE}
 }
+
+@inproceedings{martin2018parallelizing,
+  title={Parallelizing Linear Recurrent Neural Nets Over Sequence Length},
+  author={Martin, Eric and Cundy, Chris},
+  booktitle={International Conference on Learning Representations},
+  year={2018}
+}

--- a/src/grafx/processors/core/iir.py
+++ b/src/grafx/processors/core/iir.py
@@ -63,8 +63,8 @@ class IIRFilter(nn.Module):
         The third one, :python:`"ssm"`, is based on the diagonalisation of the state-space model (SSM) of the biquad filter so it only works for the second-order filters.
         The direct form I implementation of the biquad filter can be written in state-space form :cite:`smith2007introduction` as
         $$
-        x_i[m+1] &= A_i x_i[m] + B_i s[m], \\
-        y_i[m] &= C_i x_i[m] + b_{i, 0} s[m],
+        x_i[n+1] &= A_i x_i[n] + B_i s[n], \\
+        y_i[n] &= C_i x_i[n] + b_{i, 0} s[n],
         $$
         $$
         A_i = \begin{bmatrix}-a_{i, 1} & -a_{i, 2} \\ 1 & 0 \end{bmatrix}, \quad 
@@ -72,7 +72,7 @@ class IIRFilter(nn.Module):
         C_i = \begin{bmatrix}b_{i, 1} - b_{i, 0} a_{i, 1} & b_{i, 2} - b_{i, 0} a_{i, 2} \end{bmatrix}.
         $$
         If the poles of the filter are unique, the transition matrix $A_i$ can be decomposed as $A_i = V_i \Lambda_i V_i^{-1}$ where $\Lambda_i$ is either a diagonal matrix of real poles or a scaled rotation matrix, which can be represented by one of the complex conjugate poles.
-        Using this decomposition, the filter can be implemented as first-order recursive filters on the projected siganl $V_i^{-1} B_i s[m]$, where we can leverage `parallel_scan` :cite:`martin2018parallelizing` to speed up the computation on the GPU.
+        Using this decomposition, the filter can be implemented as first-order recursive filters on the projected siganl $V_i^{-1} B_i s[n]$, where we can leverage `parallel_scan` :cite:`martin2018parallelizing` to speed up the computation on the GPU.
         Finally, the output is projected back to the original basis using $V_i$. 
 
         We recommend using the :python:`"ssm"` over the :python:`"lfilter"` backend in general, as the former runs several times faster on the GPU and is more numerically stable than the latter.

--- a/src/grafx/processors/core/iir.py
+++ b/src/grafx/processors/core/iir.py
@@ -64,12 +64,12 @@ class IIRFilter(nn.Module):
         The direct form I implementation of the biquad filter can be written in state-space form :cite:`smith2007introduction` as
         $$
         x_i[n+1] &= A_i x_i[n] + B_i s[n], \\
-        y_i[n] &= C_i x_i[n] + b_{i, 0} s[n],
+        y_i[n] &= C_i x_i[n] + \bar{b}_{i, 0} s[n],
         $$
         $$
-        A_i = \begin{bmatrix}-a_{i, 1} & -a_{i, 2} \\ 1 & 0 \end{bmatrix}, \quad 
+        A_i = \begin{bmatrix}-\bar{a}_{i, 1} & -\bar{a}_{i, 2} \\ 1 & 0 \end{bmatrix}, \quad 
         B_i &= \begin{bmatrix}1 \\ 0 \end{bmatrix}, \quad 
-        C_i = \begin{bmatrix}b_{i, 1} - b_{i, 0} a_{i, 1} & b_{i, 2} - b_{i, 0} a_{i, 2} \end{bmatrix}.
+        C_i = \begin{bmatrix}\bar{b}_{i, 1} - \bar{b}_{i, 0} \bar{a}_{i, 1} & \bar{b}_{i, 2} - \bar{b}_{i, 0} \bar{a}_{i, 2} \end{bmatrix}.
         $$
         If the poles of the filter are unique, the transition matrix $A_i$ can be decomposed as $A_i = V_i \Lambda_i V_i^{-1}$ where $\Lambda_i$ is either a diagonal matrix with real poles on the diagonal or a scaled rotation matrix, which can be represented by one of the complex conjugate poles.
         Using this decomposition, the filter can be implemented as first-order recursive filters on the projected siganl $V_i^{-1} B_i s[n]$, where we leverage `Parallel Scan` :cite:`martin2018parallelizing` to speed up the computation on the GPU.
@@ -85,8 +85,8 @@ class IIRFilter(nn.Module):
             making the number of learnable parameters $5$ per biquad instead of $6$
             (default: :python:`False`).
         backend (:python:`str`, *optional*):
-            The backend to use for the filtering, which can either be the frequency-sampling method
-            :python:`"fsm"` or exact time-domain filter :python:`"lfilter"` (default: :python:`"fsm"`).
+            The backend to use for the filtering, which can either be the frequency-sampling method :python:`"fsm"` 
+            or exact time-domain filters, :python:`"lfilter"` or :python:`"ssm"` (default: :python:`"fsm"`).
         fsm_fir_len (:python:`int`, *optional*):
             The length of FIR approximation when :python:`backend == "fsm"` (default: :python:`8192`).
     """

--- a/src/grafx/processors/core/iir.py
+++ b/src/grafx/processors/core/iir.py
@@ -273,7 +273,7 @@ def _ssm_complex_conjugate(x, b12, complex_pole: torch.Tensor):
     #     |0  Im(p)|
     # V = |-1  Re(p)|
     #
-    # The rotation matrix R is given by
+    # The matrix R is given by
     #     |Re(p)  -Im(p)|
     # R = |Im(p)   Re(p)|
     # which is a rotation matrix and can be written as complex exponential |p|e^{j angle(p)} = p.

--- a/src/grafx/processors/core/iir.py
+++ b/src/grafx/processors/core/iir.py
@@ -71,8 +71,8 @@ class IIRFilter(nn.Module):
         B_i &= \begin{bmatrix}1 \\ 0 \end{bmatrix}, \quad 
         C_i = \begin{bmatrix}b_{i, 1} - b_{i, 0} a_{i, 1} & b_{i, 2} - b_{i, 0} a_{i, 2} \end{bmatrix}.
         $$
-        If the poles of the filter are unique, the transition matrix $A_i$ can be decomposed as $A_i = V_i \Lambda_i V_i^{-1}$ where $\Lambda_i$ is either a diagonal matrix of real poles or a scaled rotation matrix, which can be represented by one of the complex conjugate poles.
-        Using this decomposition, the filter can be implemented as first-order recursive filters on the projected siganl $V_i^{-1} B_i s[n]$, where we can leverage `Parallel Scan` :cite:`martin2018parallelizing` to speed up the computation on the GPU.
+        If the poles of the filter are unique, the transition matrix $A_i$ can be decomposed as $A_i = V_i \Lambda_i V_i^{-1}$ where $\Lambda_i$ is either a diagonal matrix with real poles on the diagonal or a scaled rotation matrix, which can be represented by one of the complex conjugate poles.
+        Using this decomposition, the filter can be implemented as first-order recursive filters on the projected siganl $V_i^{-1} B_i s[n]$, where we leverage `Parallel Scan` :cite:`martin2018parallelizing` to speed up the computation on the GPU.
         Finally, the output is projected back to the original basis using $V_i$. 
 
         We recommend using the :python:`"ssm"` over the :python:`"lfilter"` backend in general, as the former runs several times faster on the GPU and is more numerically stable than the latter.

--- a/src/grafx/processors/core/iir.py
+++ b/src/grafx/processors/core/iir.py
@@ -61,7 +61,7 @@ class IIRFilter(nn.Module):
         where $h[n]$ is the true infinite impulse response (IIR). Clearly, increasing the number of samples $N$ reduces the error.
 
         The third one, :python:`"ssm"`, is based on the diagonalisation of the state-space model (SSM) of the biquad filter so it only works for the second-order filters.
-        The direct form I implementation of the biquad filter can be written in state-space form :cite:`smith2007introduction` as
+        The direct form II implementation of the biquad filter can be written in state-space form :cite:`smith2007introduction` as
         $$
         x_i[n+1] &= A_i x_i[n] + B_i s[n], \\
         y_i[n] &= C_i x_i[n] + \bar{b}_{i, 0} s[n],

--- a/src/grafx/processors/core/iir.py
+++ b/src/grafx/processors/core/iir.py
@@ -180,9 +180,9 @@ class IIRFilter(nn.Module):
         else:
             assert num_channels == Bs.shape[1], "The number of channels must match."
 
-        input_signal = input_signal.view(batch * num_channels, audio_len)
-        Bs = Bs.view(batch * num_channels, -1, 3)
-        As = As.view(batch * num_channels, -1, 3)
+        input_signal = input_signal.reshape(batch * num_channels, audio_len)
+        Bs = Bs.reshape(batch * num_channels, -1, 3)
+        As = As.reshape(batch * num_channels, -1, 3)
         K = Bs.shape[1]
 
         # normalise the coefficients so that a_0 = 1
@@ -242,7 +242,7 @@ class IIRFilter(nn.Module):
             input_signal,
         )
 
-        return output_signal.view(batch, num_channels, audio_len)
+        return output_signal.reshape(batch, num_channels, audio_len)
 
     @staticmethod
     def iir_fsm(Bs, As, delays, eps=1e-10):
@@ -305,7 +305,7 @@ def _ssm_real_pole(x, b12, poles):
         * (torch.stack([pole_1, -pole_2], dim=-1) / diff[:, None])[..., None]
     )
     h = _first_order_recursive_filter(
-        u.view(-1, u.shape[-1]), poles.view(-1, 1)
+        u.reshape(-1, u.shape[-1]), poles.reshape(-1)
     ).view_as(u)
     b1 = b12[..., :1]
     b2 = b12[..., 1:]

--- a/src/grafx/processors/core/iir.py
+++ b/src/grafx/processors/core/iir.py
@@ -75,7 +75,7 @@ class IIRFilter(nn.Module):
         Using this decomposition, the filter can be implemented as first-order recursive filters on the projected siganl $V_i^{-1} B_i s[n]$, where we leverage `Parallel Scan` :cite:`martin2018parallelizing` to speed up the computation on the GPU.
         Finally, the output is projected back to the original basis using $V_i$. 
 
-        We recommend using the :python:`"ssm"` over the :python:`"lfilter"` backend in general, as the former runs several times faster on the GPU and is more numerically stable than the latter.
+        We recommend using the :python:`"ssm"` over the :python:`"lfilter"` backend in general, not only because it runs several times faster on the GPU but it's more numerically stable.
 
     Args:
         num_filters (:python:`int`, *optional*):

--- a/src/grafx/processors/core/iir.py
+++ b/src/grafx/processors/core/iir.py
@@ -72,7 +72,7 @@ class IIRFilter(nn.Module):
         C_i = \begin{bmatrix}b_{i, 1} - b_{i, 0} a_{i, 1} & b_{i, 2} - b_{i, 0} a_{i, 2} \end{bmatrix}.
         $$
         If the poles of the filter are unique, the transition matrix $A_i$ can be decomposed as $A_i = V_i \Lambda_i V_i^{-1}$ where $\Lambda_i$ is either a diagonal matrix of real poles or a scaled rotation matrix, which can be represented by one of the complex conjugate poles.
-        Using this decomposition, the filter can be implemented as first-order recursive filters on the projected siganl $V_i^{-1} B_i s[n]$, where we can leverage `parallel_scan` :cite:`martin2018parallelizing` to speed up the computation on the GPU.
+        Using this decomposition, the filter can be implemented as first-order recursive filters on the projected siganl $V_i^{-1} B_i s[n]$, where we can leverage `Parallel Scan` :cite:`martin2018parallelizing` to speed up the computation on the GPU.
         Finally, the output is projected back to the original basis using $V_i$. 
 
         We recommend using the :python:`"ssm"` over the :python:`"lfilter"` backend in general, as the former runs several times faster on the GPU and is more numerically stable than the latter.


### PR DESCRIPTION
As the title says. Note that the performance gain on GPU needs `torchlpc>=0.5` which includes the parallel scan numba kernel. A test function is added to verify `lfilter` and `ssm` give the same results.

### Notes
- I added two files (not committed), `tests/__init__.py` and `tests/processors/__init__.py`, to get `pytest` to work. I'm unsure how it will be when running the tests on CICD.
- `clamp=False` is hard-coded in `lfilter`, as I don't think setting it to `True` makes sense for audio applications, and it also enables comparing its results with other backends. A historical feature added in early `torchaudio` to solve the numerical instability of the direct form filter...
- How are the doc pages deployed? Should I commit my locally built doc pages to this PR or do something else?